### PR TITLE
Add GitHub Actions workflow for NSOC label management

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,64 @@
+name: NSOC Label
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  manage-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure NSOC label exists (Orange)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const labelName = "NSOC'26";
+            const color = "FFA500";
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName
+              });
+
+              await github.rest.issues.updateLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: color
+              });
+
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: color,
+                description: "NSOC 2026 Issues"
+              });
+            }
+
+      - name: Detect NSOC variations and apply label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title.toLowerCase();
+
+            const keywords = ["nsoc", "nsoc26", "nsoc'26", "nsoc 26", "nsoc-26"];
+            const isNSOC = keywords.some(k => title.includes(k));
+
+            if (isNSOC) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ["NSOC'26"]
+              });
+            }


### PR DESCRIPTION
This workflow ensures the NSOC label exists and applies it to issues with relevant keywords.

@bishal2623 
merge this

Closes #19 
