### PR TITLE
Add input size limits to AI flow schemas

### DIFF
--- a/src/ai/flows/answer-contract-questions.ts
+++ b/src/ai/flows/answer-contract-questions.ts
@@ -11,6 +11,7 @@ import {z} from 'genkit';
 const AnswerContractQuestionInputSchema = z.object({
   contractText: z
     .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
     .describe('The complete text of the legal contract to analyze.'),
   question: z.string().describe('The specific question about the contract.'),
 });

--- a/src/ai/flows/extract-key-terms-and-dates.ts
+++ b/src/ai/flows/extract-key-terms-and-dates.ts
@@ -13,6 +13,7 @@ import {z} from 'genkit';
 const ExtractKeyTermsAndDatesInputSchema = z.object({
   legalDocument: z
     .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
     .describe('The legal document from which to extract key terms and dates.'),
 });
 export type ExtractKeyTermsAndDatesInput = z.infer<

--- a/src/ai/flows/highlight-contract-risks.ts
+++ b/src/ai/flows/highlight-contract-risks.ts
@@ -13,7 +13,7 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const HighlightContractRisksInputSchema = z.object({
-  legalDocument: z.string().describe('The legal document to analyze.'),
+  legalDocument: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The legal document to analyze.'),
 });
 export type HighlightContractRisksInput = z.infer<typeof HighlightContractRisksInputSchema>;
 

--- a/src/ai/flows/highlight-contract-risks.ts
+++ b/src/ai/flows/highlight-contract-risks.ts
@@ -13,7 +13,10 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const HighlightContractRisksInputSchema = z.object({
-  legalDocument: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The legal document to analyze.'),
+  legalDocument: z
+    .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
+    .describe('The legal document to analyze.'),
 });
 export type HighlightContractRisksInput = z.infer<typeof HighlightContractRisksInputSchema>;
 

--- a/src/ai/flows/parse-uploaded-document.ts
+++ b/src/ai/flows/parse-uploaded-document.ts
@@ -12,7 +12,7 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const ParseUploadedDocumentInputSchema = z.object({
-  documentText: z.string().describe('The text content of the legal document to be parsed.'),
+  documentText: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The text content of the legal document to be parsed.'),
 });
 export type ParseUploadedDocumentInput = z.infer<typeof ParseUploadedDocumentInputSchema>;
 

--- a/src/ai/flows/parse-uploaded-document.ts
+++ b/src/ai/flows/parse-uploaded-document.ts
@@ -12,7 +12,10 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const ParseUploadedDocumentInputSchema = z.object({
-  documentText: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The text content of the legal document to be parsed.'),
+  documentText: z
+    .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
+    .describe('The text content of the legal document to be parsed.'),
 });
 export type ParseUploadedDocumentInput = z.infer<typeof ParseUploadedDocumentInputSchema>;
 

--- a/src/ai/flows/search-clauses.ts
+++ b/src/ai/flows/search-clauses.ts
@@ -11,7 +11,7 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const SearchClausesInputSchema = z.object({
-  documentText: z.string().describe('The full text of the legal document to search within.'),
+  documentText: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The full text of the legal document to search within.'),
   query: z.string().describe('The search query to find relevant clauses.'),
 });
 export type SearchClausesInput = z.infer<typeof SearchClausesInputSchema>;

--- a/src/ai/flows/search-clauses.ts
+++ b/src/ai/flows/search-clauses.ts
@@ -11,7 +11,10 @@ import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
 const SearchClausesInputSchema = z.object({
-  documentText: z.string().max(100_000, 'Document text exceeds maximum length of 100,000 characters.').describe('The full text of the legal document to search within.'),
+  documentText: z
+    .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
+    .describe('The full text of the legal document to search within.'),
   query: z.string().describe('The search query to find relevant clauses.'),
 });
 export type SearchClausesInput = z.infer<typeof SearchClausesInputSchema>;

--- a/src/ai/flows/summarize-legal-document.ts
+++ b/src/ai/flows/summarize-legal-document.ts
@@ -13,6 +13,7 @@ import {z} from 'genkit';
 const SummarizeLegalDocumentInputSchema = z.object({
   legalDocument: z
     .string()
+    .max(100_000, 'Document text exceeds maximum length of 100,000 characters.')
     .describe('The legal document to summarize, in plain text.'),
 });
 export type SummarizeLegalDocumentInput = z.infer<typeof SummarizeLegalDocumentInputSchema>;


### PR DESCRIPTION
## Summary

Adds input size validation to all document text fields in AI flows to prevent denial-of-service attacks and excessive API token consumption.

This fix applies `.max(100,000 characters)` validation constraints to:
- `summarizeLegalDocument` - legalDocument field
- `parseUploadedDocument` - documentText field  
- `answerContractQuestion` - contractText field
- `highlightContractRisks` - legalDocument field
- `searchClauses` - documentText field
- `extractKeyTermsAndDates` - legalDocument field

## Vulnerability

Large document inputs could be used to:
1. Trigger excessive Gemini API token usage, incurring unexpected costs
2. Cause request timeouts or service degradation
3. Exhaust memory on the server

## Resolution

Added Zod validation constraints with clear error messages to enforce a reasonable 100,000 character limit. This allows legitimate legal documents while preventing abuse.

## Testing

- All input schemas now validate document size before flow execution
- Oversized documents will be rejected with descriptive error messages
- API calls are protected from excessive token usage

Resolves #127