### PR TITLE
Remove build error suppression from next.config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,5 @@
 import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

Removes `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` configurations from `next.config.ts` to enforce proper type checking and linting during builds.

## Rationale

Silently ignoring build errors masks code quality issues and makes it harder to catch bugs before they reach production. By removing these suppression flags, the project can:
- Catch TypeScript type errors at build time
- Enforce ESLint rules consistently
- Maintain code quality standards
- Provide better developer experience with clear error feedback

## Changes

- Removed `typescript.ignoreBuildErrors: true` configuration
- Removed `eslint.ignoreDuringBuilds: true` configuration
- Configuration now relies on actual code quality rather than error suppression

## Testing

The build process will now properly report any TypeScript or ESLint errors that exist in the codebase, allowing them to be fixed separately.

Resolves #126