### PR TITLE
fix(document-input): implement drag-and-drop with visual feedback and file reading

### DIFF
--- a/src/components/legiflow/document-input.tsx
+++ b/src/components/legiflow/document-input.tsx
@@ -1,10 +1,10 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import { LoaderCircle } from 'lucide-react';
+import { FileText, LoaderCircle, Upload } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 
 interface DocumentInputProps {
@@ -12,8 +12,36 @@ interface DocumentInputProps {
   isLoading: boolean;
 }
 
+/** File extensions accepted for direct text extraction via FileReader. */
+const ACCEPTED_EXTENSIONS = ['.txt', '.md', '.text', '.mdx'];
+
+/**
+ * Read a File object as a UTF-8 string using the FileReader API.
+ */
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve((e.target?.result as string) ?? '');
+    reader.onerror = () =>
+      reject(new Error(`Failed to read file: ${file.name}`));
+    reader.readAsText(file, 'utf-8');
+  });
+}
+
 export function DocumentInput({ onParse, isLoading }: DocumentInputProps) {
   const [text, setText] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragError, setDragError] = useState<string | null>(null);
+
+  /**
+   * A counter rather than a boolean prevents the active drag state from
+   * flickering when the pointer momentarily passes over a child element.
+   * Each dragenter increments, each dragleave decrements; only when the
+   * counter reaches zero (pointer has truly left the entire zone) do we
+   * clear isDragging.
+   */
+  const dragCounter = useRef(0);
+
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -23,6 +51,86 @@ export function DocumentInput({ onParse, isLoading }: DocumentInputProps) {
     }
   }, [searchParams]);
 
+  const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current += 1;
+    if (dragCounter.current === 1) {
+      setIsDragging(true);
+      setDragError(null);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current -= 1;
+    if (dragCounter.current === 0) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  /**
+   * onDragOver must call preventDefault to signal the browser that this is a
+   * valid drop target; without it the drop event never fires.
+   */
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      // Reset counter unconditionally so state is always consistent.
+      dragCounter.current = 0;
+      setIsDragging(false);
+      setDragError(null);
+
+      const { files } = e.dataTransfer;
+
+      if (files && files.length > 0) {
+        const file = files[0];
+        const dotIndex = file.name.lastIndexOf('.');
+        const ext =
+          dotIndex !== -1 ? file.name.slice(dotIndex).toLowerCase() : '';
+
+        const isAccepted =
+          file.type.startsWith('text/') || ACCEPTED_EXTENSIONS.includes(ext);
+
+        if (!isAccepted) {
+          setDragError(
+            `"${file.name}" is not supported. Please drop a plain-text (.txt) or Markdown (.md) file.`
+          );
+          return;
+        }
+
+        try {
+          const content = await readFileAsText(file);
+          if (content.trim()) {
+            setText(content);
+          } else {
+            setDragError('The dropped file appears to be empty.');
+          }
+        } catch {
+          setDragError(
+            'Could not read the dropped file. Please paste the document text directly.'
+          );
+        }
+        return;
+      }
+
+      // Fallback: handle plain text dragged from another application or tab.
+      const droppedText = e.dataTransfer.getData('text/plain');
+      if (droppedText.trim()) {
+        setText(droppedText);
+      }
+    },
+    []
+  );
+
   const handleSubmit = () => {
     if (text.trim()) {
       onParse(text.trim());
@@ -31,21 +139,57 @@ export function DocumentInput({ onParse, isLoading }: DocumentInputProps) {
 
   return (
     <div className="space-y-4">
-        <div className="border-2 border-dashed border-border/20 p-6 text-center rounded-lg">
-            <h3 className="font-bold">Drag & drop or paste text</h3>
-            <p className="text-muted-foreground text-sm">We will extract text and run a quick analysis.</p>
-            <Textarea
-              placeholder="Paste the text of your legal document here..."
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              className="min-h-64 text-base bg-transparent focus:border-primary font-sans my-4"
-              disabled={isLoading}
-            />
-        </div>
-        <Button onClick={handleSubmit} className="w-full sm:w-auto" disabled={isLoading || !text.trim()}>
-          {isLoading ? <LoaderCircle className="animate-spin mr-2" /> : null}
-          Analyze Document
-        </Button>
+      <div
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        className={[
+          'relative border-2 border-dashed p-6 text-center rounded-lg transition-colors duration-150',
+          isDragging ? 'border-primary bg-primary/5' : 'border-border/20',
+        ].join(' ')}
+      >
+        {/* Full-zone overlay shown while a draggable payload is held over the drop area */}
+        {isDragging && (
+          <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center rounded-lg bg-primary/10">
+            <Upload className="mb-2 h-8 w-8 text-primary" />
+            <p className="font-semibold text-primary">Release to drop your file</p>
+          </div>
+        )}
+
+        <h3 className="flex items-center justify-center gap-2 font-bold">
+          <FileText className="h-4 w-4" />
+          Drag &amp; drop a file or paste text
+        </h3>
+        <p className="mb-1 text-sm text-muted-foreground">
+          Supported formats:{' '}
+          <span className="font-medium">.txt, .md</span> — or paste document
+          text directly below.
+        </p>
+
+        <Textarea
+          placeholder="Paste the text of your legal document here..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="my-4 min-h-64 bg-transparent font-sans text-base focus:border-primary"
+          disabled={isLoading}
+        />
+
+        {dragError && (
+          <p role="alert" className="mt-1 text-sm text-destructive">
+            {dragError}
+          </p>
+        )}
+      </div>
+
+      <Button
+        onClick={handleSubmit}
+        className="w-full sm:w-auto"
+        disabled={isLoading || !text.trim()}
+      >
+        {isLoading ? <LoaderCircle className="mr-2 animate-spin" /> : null}
+        Analyze Document
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #39

The drop zone advertised **"Drag & drop or paste text"** in its heading but had **zero drag event handlers**, making the feature entirely non-functional — dropping a file produced no effect at all.

---

## Root Cause

`document-input.tsx` was missing `onDragEnter`, `onDragLeave`, `onDragOver`, and `onDrop` handlers on the container `<div>`. Without `onDragOver` calling `e.preventDefault()`, browsers never consider the element a valid drop target and will not fire the `drop` event.

---

## What Changed

### `src/components/legiflow/document-input.tsx`

| Area | Before | After |
|---|---|---|
| Drag events | None | `onDragEnter`, `onDragLeave`, `onDragOver`, `onDrop` |
| Visual feedback | Static dashed border, always the same | Border turns `border-primary` + `bg-primary/5`; full-zone overlay with upload icon appears |
| Drag counter | N/A | `dragCounter` ref prevents `isDragging` flicker when pointer crosses child elements |
| File reading | Not implemented | `FileReader.readAsText()` populates textarea from `.txt` / `.md` / `.mdx` drops |
| Text drag | Not implemented | `dataTransfer.getData('text/plain')` handles dragged text selections |
| Error feedback | None | `role="alert"` error message shown for unsupported types or read failures |

### Key Implementation Details

**Drag counter pattern** — a `useRef(0)` counter is incremented on `dragenter` and decremented on `dragleave`. `isDragging` is set to `true` on the first enter and cleared to `false` only when the counter returns to 0. This prevents the common flickering bug where dragging over a child element triggers a `dragleave` on the parent.

**`onDragOver` must call `preventDefault()`** — without this, the browser does not recognise the element as a drop target and the `drop` event never fires (the original bug).

**`e.dataTransfer.dropEffect = 'copy'`** — communicates the intended action to the OS, showing the correct cursor.

**File type validation** — checks `file.type.startsWith('text/')` and the file extension against `['.txt', '.md', '.text', '.mdx']` before attempting to read. Unsupported files surface a clear user-facing error.

**Drag counter reset on drop** — counter is unconditionally reset to 0 in `handleDrop` to keep state consistent regardless of how many children were involved.

---

## Testing

1. Open the document input page.
2. Drag a `.txt` file over the drop zone — border turns primary, overlay appears.
3. Release the file — textarea is populated with file content.
4. Drag a `.md` file — same behaviour.
5. Drag an unsupported file (e.g. `.png`) — error message appears below textarea.
6. Drag a text selection from another tab — textarea is populated.
7. Drag into the textarea child element specifically — no flickering; state remains consistent.
8. Confirm paste still works as before.

---

## Labels Request

This PR resolves a **Level 2 bug** (labelled `bug`, `frontend`, `ui/ux`, `GSSoC 26`, `Level 2` on the issue). Could you please add the following labels to this PR?

- `gssoc-approved`
- `Level 2`
- `bug`
- `frontend`

These labels are important for GSSoC 2026 point tracking. Thank you!